### PR TITLE
move from QCBOR to zcbor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+<!-- Copyright (c) 2023 Golioth, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Changelog
+
+### Changed
+- Use zcbor instead of qcbor

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2023 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config NETWORK_INFO
+	bool "Return network information to a Golioth RPC or Log function"
+	default n
+	help
+	  Enable helper library to gather and format network information
+	  for Remote Procedure Call (RPC) or Logging

--- a/include/network_info.h
+++ b/include/network_info.h
@@ -7,7 +7,7 @@
 #ifndef __NETWORK_INFO_H__
 #define __NETWORK_INFO_H__
 
-#include <qcbor/qcbor.h>
+#include <zcbor_encode.h>
 
 /**
  * @brief Initialize the Network Info file for this board
@@ -29,7 +29,7 @@ int network_info_init(void);
  * @retval 0 On success
  * @retval <0 On failure
  */
-int network_info_add_to_map(QCBOREncodeContext *response_detail_map);
+int network_info_add_to_map(zcbor_state_t *response_detail_map);
 
 /**
  * @brief Write network information as a LOG message

--- a/network_info_modem_info.c
+++ b/network_info_modem_info.c
@@ -7,8 +7,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_info, LOG_LEVEL_DBG);
 
-#include <network_info.h>
 #include <modem/modem_info.h>
+#include <net/golioth/rpc.h>
+#include <network_info.h>
 
 int network_info_init(void)
 {
@@ -20,63 +21,107 @@ int network_info_init(void)
 	return 0;
 }
 
-int network_info_add_to_map(QCBOREncodeContext *response_detail_map)
+int network_info_add_to_map(zcbor_state_t *response_detail_map)
 {
 	char sbuf[128];
-	modem_info_string_get(MODEM_INFO_RSRP, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Signal strength",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_CUR_BAND, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Current LTE band",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_SUP_BAND, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Supported LTE bands",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_AREA_CODE, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Tracking area code",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_UE_MODE, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Current mode",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_OPERATOR, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Current operator name",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_CELLID, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Cell ID of the device",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_IP_ADDRESS, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "IP address of the device",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_FW_VERSION, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Modem firmware version",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_LTE_MODE, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "LTE-M support mode",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_NBIOT_MODE, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "NB-IoT support mode",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_GPS_MODE, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "GPS support mode",
-				     sbuf);
-	modem_info_string_get(MODEM_INFO_DATE_TIME, sbuf, sizeof(sbuf));
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "Mobile network time and date",
-				     sbuf);
+	bool ok;
 
-	return 0;
+	modem_info_string_get(MODEM_INFO_RSRP, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Signal strength") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_CUR_BAND, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Current LTE band") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_SUP_BAND, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Supported LTE bands") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_AREA_CODE, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Tracking area code") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_UE_MODE, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Current mode") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_OPERATOR, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Current operator name") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_CELLID, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Cell ID of the device") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_IP_ADDRESS, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "IP address of the device") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_FW_VERSION, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Modem firmware version") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_LTE_MODE, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "LTE-M support mode") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_NBIOT_MODE, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "NB-IoT support mode") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_GPS_MODE, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "GPS support mode") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	modem_info_string_get(MODEM_INFO_DATE_TIME, sbuf, sizeof(sbuf));
+	ok = zcbor_tstr_put_lit(response_detail_map, "Mobile network time and date") &&
+	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	if (!ok) {
+		goto rpc_exhausted;
+	}
+
+	return GOLIOTH_RPC_OK;
+
+rpc_exhausted:
+	LOG_ERR("Failed to encode value");
+	return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
 }
 
 int network_info_log(void)

--- a/network_info_placeholder.c
+++ b/network_info_placeholder.c
@@ -7,19 +7,27 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth_iot, LOG_LEVEL_DBG);
 
+#include <net/golioth/rpc.h>
 #include <network_info.h>
 
 int __attribute__((weak)) network_info_init(void) {
 	return 0;
 }
 
-int __attribute__((weak)) network_info_add_to_map(QCBOREncodeContext *response_detail_map)
+int __attribute__((weak)) network_info_add_to_map(zcbor_state_t *response_detail_map)
 {
-	QCBOREncode_AddSZStringToMap(response_detail_map,
-				     "No Network Info",
-				     "Network reporting not implemented "
-				     "for this board");
-	return 0;
+	bool ok;
+
+	ok = zcbor_tstr_put_lit(response_detail_map, "No Network Info") &&
+	     zcbor_tstr_put_lit(response_detail_map,
+				"Network reporting not implemented for this hardware");
+
+	if (!ok) {
+		LOG_ERR("Failed to encode value");
+		return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
+	}
+
+	return GOLIOTH_RPC_OK;
 }
 
 int __attribute__((weak)) network_info_log(void)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake: .
+  kconfig: Kconfig


### PR DESCRIPTION
* Use zcbor for compatibility with Golioth Zephyr SDK v0.7.1
* Convert to a module for use from modules/lib/network-info