### PR TITLE
change include file to use Golioth Firmware SDK

### DIFF
--- a/network_info_modem_info.c
+++ b/network_info_modem_info.c
@@ -8,7 +8,7 @@
 LOG_MODULE_REGISTER(net_info, LOG_LEVEL_DBG);
 
 #include <modem/modem_info.h>
-#include <net/golioth/rpc.h>
+#include <golioth/rpc.h>
 #include <network_info.h>
 #include <zephyr/init.h>
 

--- a/network_info_nrf7002dk.c
+++ b/network_info_nrf7002dk.c
@@ -7,7 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_info, LOG_LEVEL_DBG);
 
-#include <net/golioth/rpc.h>
+#include <golioth/rpc.h>
 #include <network_info.h>
 #include "../wifi_util.h"
 

--- a/network_info_placeholder.c
+++ b/network_info_placeholder.c
@@ -7,7 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth_iot, LOG_LEVEL_DBG);
 
-#include <net/golioth/rpc.h>
+#include <golioth/rpc.h>
 #include <network_info.h>
 
 int __attribute__((weak)) network_info_add_to_map(zcbor_state_t *response_detail_map)


### PR DESCRIPTION
This repository was originally written to work with the Golioth Zephyr SDK. This commit changes to use the Golioth Firmware SDK (which now includes Zephyr support) by changing the necessary include.