### PR TITLE
Better zcbor encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] 2024-03-21
+
+### Breaking Changes
+- This library requires Golioth Firmware SDK v0.11.1 or newer which implements
+  CONFIG_GOLIOTH_RPC_MAX_RESPONSE_LEN
+
+### Changed
+- Better checks and logs when zcbor encoding runs out of memory
+
 ## [1.1.0] 2024-02-09
 
 ### Changed

--- a/network_info_modem_info.c
+++ b/network_info_modem_info.c
@@ -122,7 +122,8 @@ int network_info_add_to_map(zcbor_state_t *response_detail_map)
 	return GOLIOTH_RPC_OK;
 
 rpc_exhausted:
-	LOG_ERR("Failed to encode value");
+	LOG_ERR("Failed to encode some values; response might be too long (CONFIG_GOLIOTH_RPC_MAX_RESPONSE_LEN: %d)",
+		CONFIG_GOLIOTH_RPC_MAX_RESPONSE_LEN);
 	return GOLIOTH_RPC_RESOURCE_EXHAUSTED;
 }
 


### PR DESCRIPTION
- Check for out-of-memory after adding each value to cbor
- Log message to indicate the Kconfig symbol to adjust when out of memory

The first commit looks like a lot of changes, but it really just implements the pattern used by the modem info file to check after trying to add each value to the CBOR map.