### PR TITLE
Release/1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] 2024-09-04
+
+### Changed
+- Update zcbor syntax to work with ZCBOR v0.8.0 (NCS v2.7.0, Golioth Firmware SDK v0.15.0)
+
 ## [1.1.1] 2024-03-21
 
 ### Breaking Changes

--- a/network_info_modem_info.c
+++ b/network_info_modem_info.c
@@ -30,91 +30,91 @@ int network_info_add_to_map(zcbor_state_t *response_detail_map)
 
 	modem_info_string_get(MODEM_INFO_RSRP, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Signal strength") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_CUR_BAND, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Current LTE band") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_SUP_BAND, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Supported LTE bands") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_AREA_CODE, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Tracking area code") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_UE_MODE, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Current mode") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_OPERATOR, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Current operator name") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_CELLID, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Cell ID of the device") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_IP_ADDRESS, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "IP address of the device") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_FW_VERSION, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Modem firmware version") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_LTE_MODE, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "LTE-M support mode") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_NBIOT_MODE, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "NB-IoT support mode") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_GPS_MODE, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "GPS support mode") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
 
 	modem_info_string_get(MODEM_INFO_DATE_TIME, sbuf, sizeof(sbuf));
 	ok = zcbor_tstr_put_lit(response_detail_map, "Mobile network time and date") &&
-	     zcbor_tstr_put_term(response_detail_map, sbuf);
+	     zcbor_tstr_put_term(response_detail_map, sbuf, 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}

--- a/network_info_nrf7002dk.c
+++ b/network_info_nrf7002dk.c
@@ -25,7 +25,7 @@ int network_info_add_to_map(zcbor_state_t *response_detail_map)
 	cmd_wifi_status(&w_status);
 
 	ok = zcbor_tstr_put_lit(response_detail_map, "State") &&
-		zcbor_tstr_put_term(response_detail_map, wifi_state_txt(w_status.state));
+		zcbor_tstr_put_term(response_detail_map, wifi_state_txt(w_status.state), 128);
 	if (!ok) {
 		goto rpc_exhausted;
 	}
@@ -39,29 +39,29 @@ int network_info_add_to_map(zcbor_state_t *response_detail_map)
 
 		ok = zcbor_tstr_put_lit(response_detail_map, "Interface Mode") &&
 		     zcbor_tstr_put_term(response_detail_map,
-				         wifi_mode_txt(w_status.iface_mode));
+				         wifi_mode_txt(w_status.iface_mode), 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "Link Mode") &&
 		     zcbor_tstr_put_term(response_detail_map,
-				         wifi_link_mode_txt(w_status.link_mode));
+				         wifi_link_mode_txt(w_status.link_mode), 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "SSID") &&
-		     zcbor_tstr_put_term(response_detail_map, w_status.ssid);
+		     zcbor_tstr_put_term(response_detail_map, w_status.ssid, 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "BSSID") &&
-		     zcbor_tstr_put_term(response_detail_map, mac_string_buf);
+		     zcbor_tstr_put_term(response_detail_map, mac_string_buf, 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "Band") &&
 		     zcbor_tstr_put_term(response_detail_map,
-				         wifi_band_txt(w_status.band));
+				         wifi_band_txt(w_status.band), 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
@@ -72,13 +72,13 @@ int network_info_add_to_map(zcbor_state_t *response_detail_map)
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "Security") &&
 		     zcbor_tstr_put_term(response_detail_map,
-				         wifi_security_txt(w_status.security));
+				         wifi_security_txt(w_status.security), 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}
 		ok = zcbor_tstr_put_lit(response_detail_map, "MFP") &&
 		     zcbor_tstr_put_term(response_detail_map,
-				         wifi_mfp_txt(w_status.mfp));
+				         wifi_mfp_txt(w_status.mfp), 128);
 		if (!ok) {
 			goto rpc_exhausted;
 		}


### PR DESCRIPTION
Update to work with Golioth Firmware SDK v0.15.0.

This version of Golioth moves to a dependency on ZCBOR v0.8.* which includes a syntax change.